### PR TITLE
bind to 0.0.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Now start the API server:
 
 ```
 cd /vagrant/evercam-api
-bundle exec rackup
+bundle exec rackup -o 0.0.0.0
 ```
 
 And in another terminal tab/window start the Dashboard server:


### PR DESCRIPTION
without binding to 0.0.0.0, evercam-api is not accessible from the host machine.